### PR TITLE
Add configurability of signals sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ these signals you might be able to defeat the deadly `OOMKiller`.
 ### How it works
 
 This sidecar will send your container two signals: when memory usage crosses
-so called _warning_(**SIGUSR1**) and _critical_(**SIGUSR2**) thresholds. Your 
-application therefore must be able to deal with these signals by implementing
+so called _warning_(**SIGUSR1** by default) and _critical_(**SIGUSR2** by default) thresholds. 
+It is possible to use different signals by specifying appropriate environment variables.
+Your application must be able to deal with these signals by implementing
 signal handlers.
 
 You an see [here](https://github.com/ricardomaraschini/oomhero/blob/master/cmd/bloat/main.go)
@@ -78,6 +79,42 @@ $ # for bloat container log
 $ kubectl logs -f oomhero --container bloat
 $ # for oomhero container log
 $ kubectl logs -f oomhero --container oomhero 
+```
+
+### Configuring signals
+Signals supported by `OOMHero` are:
+- SIGABRT
+- SIGCONT
+- SIGHUP
+- SIGINT
+- SIGIOT
+- SIGKILL
+- SIGQUIT
+- SIGSTOP
+- SIGTERM
+- SIGTSTP
+- SIGUSR1
+- SIGUSR2
+
+To use any of those signals instead of default ones, set `WARNING_SIGNAL` and `CRITICAL_SIGNAL`
+environment variable to specify _warning_ and _critical_ signals respectively.
+If those environment variables are not set, `OOMHero` will use default values (SIGUSR1 and SIGUSR2).
+
+For instance to send `SIGTERM` when critical threshold is reached put following in pod or deployment definition:
+
+```yaml
+containers:
+  # other containers ommited for brevity
+  - name: oomhero
+    image: quay.io/rmarasch/oomhero
+    imagePullPolicy: Always
+    env:
+    - name: WARNING
+      value: "65"
+    - name: CRITICAL
+      value: "90"
+    - name: CRITICAL_SIGNAL
+      value: "SIGTERM"
 ```
 
 ### Help needed

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For instance to send `SIGTERM` when critical threshold is reached put following 
 
 ```yaml
 containers:
-  # other containers ommited for brevity
+  # other containers omitted for brevity
   - name: oomhero
     image: quay.io/rmarasch/oomhero
     imagePullPolicy: Always

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -17,6 +17,21 @@ var (
 	// CriticalSignal is the signal sent to the process once we reach what
 	// is considered a Critical threshold.
 	CriticalSignal = syscall.SIGUSR2
+
+	supportedSignals = map[string]syscall.Signal{
+		"SIGABRT": syscall.SIGABRT,
+		"SIGCONT": syscall.SIGCONT,
+		"SIGHUP":  syscall.SIGHUP,
+		"SIGINT":  syscall.SIGINT,
+		"SIGIOT":  syscall.SIGIOT,
+		"SIGKILL": syscall.SIGKILL,
+		"SIGQUIT": syscall.SIGQUIT,
+		"SIGSTOP": syscall.SIGSTOP,
+		"SIGTERM": syscall.SIGTERM,
+		"SIGTSTP": syscall.SIGTSTP,
+		"SIGUSR1": syscall.SIGUSR1,
+		"SIGUSR2": syscall.SIGUSR2,
+	}
 )
 
 // CmdLine returns the command line for proc.
@@ -70,12 +85,32 @@ func Others() ([]*os.Process, error) {
 
 // SendWarning sends a warning signal to a list or processes.
 func SendWarning(ps []*os.Process) error {
-	return sendSignal(WarningSignal, ps)
+	signal := resolveWarningSignal()
+	return sendSignal(signal, ps)
+}
+
+func resolveWarningSignal() syscall.Signal {
+	envSignal := os.Getenv("WARNING_SIGNAL")
+	if val, ok := supportedSignals[envSignal]; ok {
+		return val
+	}
+
+	return syscall.SIGUSR1
 }
 
 // SendCritical sends a critical signal to a list or processes.
 func SendCritical(ps []*os.Process) error {
-	return sendSignal(CriticalSignal, ps)
+	signal := resolveCriticalSignal()
+	return sendSignal(signal, ps)
+}
+
+func resolveCriticalSignal() syscall.Signal {
+	envSignal := os.Getenv("CRITICAL_SIGNAL")
+	if val, ok := supportedSignals[envSignal]; ok {
+		return val
+	}
+
+	return syscall.SIGUSR2
 }
 
 func sendSignal(sig syscall.Signal, ps []*os.Process) error {


### PR DESCRIPTION
Solves #13 

This pull request includes changes to code and documentation.

I am not a Go developer, please point out any silly mistakes I have done.

I decided to add handling of only a subset of available signals, only the ones I imagined one might want to send to a process when memory consumption is growing. I wanted signals to be specified by name in environment variables, but I did not find any function in std to convert from name to a signal - if such a function exists, please point me to it.