### PR TITLE
Migrate COOLDOWN to time.ParseDuration format

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This might be undesireable behavior in some circumstances, therefore cooldown ca
 Once set, signal will be sent no more often than once in `cooldown` for each signal type separately.
 In other words other processes would not receive more than one warning and one ciritcal signal more often than once in `cooldown`.
 
-To configure cooldown set `COOLDOWN` environment variable in deployment definition to a desired number of seconds:
+To configure cooldown set `COOLDOWN` environment variable in deployment definition to a value conforming to [time.ParseDuartion](https://pkg.go.dev/time#ParseDuration):
 ```yaml
 containers:
   # other containers omitted for brevity
@@ -135,8 +135,7 @@ containers:
     imagePullPolicy: Always
     env:
     - name: COOLDOWN
-      # cooldown's unit is seconds
-      value: "60"
+      value: "1m30s"
 ```
 
 ### Help needed

--- a/cmd/oomhero/main.go
+++ b/cmd/oomhero/main.go
@@ -12,7 +12,7 @@ import (
 var (
 	warning  uint64        = 75
 	critical uint64        = 90
-	cooldown time.Duration = 1 * time.Second
+	cooldown time.Duration = time.Second
 )
 
 func main() {
@@ -114,7 +114,7 @@ func readCooldownFromEnvironment() {
 
 	cooldownEnv := val
 
-	if cooldownEnv < 0*time.Second {
+	if cooldownEnv < 0 {
 		log.Print("cooldown must be a positive number")
 		return
 	}

--- a/cmd/oomhero/main.go
+++ b/cmd/oomhero/main.go
@@ -10,19 +10,22 @@ import (
 )
 
 var (
-	warning  uint64 = 75
-	critical uint64 = 90
-	cooldown uint64 = 1
+	warning  uint64        = 75
+	critical uint64        = 90
+	cooldown time.Duration = 1 * time.Second
 )
 
 func main() {
-	log.Printf("warning threshold set to %d%%", warning)
-	log.Printf("critical threshold set to %d%%", critical)
 	watchProcesses(time.NewTicker(time.Second).C, getOsProcesses)
 }
 
 func watchProcesses(ticks <-chan time.Time, getProcesses func() ([]proc.Process, error)) {
-	readEnvironmentVariables()
+	readThresholdsFromEnvironment()
+	readCooldownFromEnvironment()
+
+	log.Printf("warning threshold set to %d%%", warning)
+	log.Printf("critical threshold set to %d%%", critical)
+	log.Printf("cooldown set to %v", cooldown)
 
 	processSignalTracker := make(map[int]*ProcessWatcher)
 
@@ -74,10 +77,9 @@ func watchProcesses(ticks <-chan time.Time, getProcesses func() ([]proc.Process,
 }
 
 // reads warning and critical from environment or use the default ones.
-func readEnvironmentVariables() {
+func readThresholdsFromEnvironment() {
 	warningEnv := envVarToUint64("WARNING", warning)
 	criticalEnv := envVarToUint64("CRITICAL", critical)
-	cooldownEnv := envVarToUint64("COOLDOWN", cooldown)
 
 	if warningEnv > 100 || criticalEnv > 100 {
 		log.Print("warning and critical must be lower or equal to 100")
@@ -89,6 +91,34 @@ func readEnvironmentVariables() {
 
 	warning = warningEnv
 	critical = criticalEnv
+}
+
+func readCooldownFromEnvironment() {
+	asString := os.Getenv("COOLDOWN")
+	if asString == "" {
+		return
+	}
+
+	val, err := time.ParseDuration(asString)
+	if err != nil {
+		log.Printf("error parsing COOLDOWN with time.ParseDuration: %v", err)
+		log.Print("falling back to legacy behavior")
+		legacyVal, err := strconv.ParseUint(asString, 10, 64)
+		if err != nil {
+			log.Printf("error parsing COOLDOWN as uint: %v", err)
+			return
+		}
+		log.Print("detected usage of deprecated format of COOLDOWN, migrate to time.ParseDuration format as soon as possible")
+		val = time.Duration(legacyVal) * time.Second
+	}
+
+	cooldownEnv := val
+
+	if cooldownEnv < 0*time.Second {
+		log.Print("cooldown must be a positive number")
+		return
+	}
+
 	cooldown = cooldownEnv
 }
 
@@ -169,8 +199,8 @@ func (p *ProcessWatcher) transitionTo(s State) {
 
 func (p *ProcessWatcher) onCooldown(now time.Time) bool {
 	if then, found := p.lastSignals[p.state]; found {
-		elapsedSince := now.Unix() - then.Unix()
-		return elapsedSince < int64(cooldown)
+		elapsedSince := now.Sub(then)
+		return elapsedSince < cooldown
 	}
 	return false
 }

--- a/cmd/oomhero/main.go
+++ b/cmd/oomhero/main.go
@@ -15,41 +15,6 @@ var (
 	cooldown uint64 = 1
 )
 
-// reads warning and critical from environment or use the default ones.
-func init() {
-	warningEnv := envVarToUint64("WARNING", warning)
-	criticalEnv := envVarToUint64("CRITICAL", critical)
-	cooldownEnv := envVarToUint64("COOLDOWN", cooldown)
-
-	if warningEnv > 100 || criticalEnv > 100 {
-		log.Print("warning and critical must be lower or equal to 100")
-		return
-	} else if warningEnv > criticalEnv {
-		log.Print("warning must be lower or equal to critical")
-		return
-	}
-
-	warning = warningEnv
-	critical = criticalEnv
-	cooldown = cooldownEnv
-}
-
-// envVarToUint64 converts the environment variable into a uint64, in case of
-// error provided default value(def) is returned instead.
-func envVarToUint64(name string, def uint64) uint64 {
-	asString := os.Getenv(name)
-	if asString == "" {
-		return def
-	}
-
-	val, err := strconv.ParseUint(asString, 10, 64)
-	if err != nil {
-		return def
-	}
-
-	return val
-}
-
 func main() {
 	log.Printf("warning threshold set to %d%%", warning)
 	log.Printf("critical threshold set to %d%%", critical)
@@ -57,6 +22,8 @@ func main() {
 }
 
 func watchProcesses(ticks <-chan time.Time, getProcesses func() ([]proc.Process, error)) {
+	readEnvironmentVariables()
+
 	processSignalTracker := make(map[int]*ProcessWatcher)
 
 	for now := range ticks {
@@ -104,6 +71,41 @@ func watchProcesses(ticks <-chan time.Time, getProcesses func() ([]proc.Process,
 			}
 		}
 	}
+}
+
+// reads warning and critical from environment or use the default ones.
+func readEnvironmentVariables() {
+	warningEnv := envVarToUint64("WARNING", warning)
+	criticalEnv := envVarToUint64("CRITICAL", critical)
+	cooldownEnv := envVarToUint64("COOLDOWN", cooldown)
+
+	if warningEnv > 100 || criticalEnv > 100 {
+		log.Print("warning and critical must be lower or equal to 100")
+		return
+	} else if warningEnv > criticalEnv {
+		log.Print("warning must be lower or equal to critical")
+		return
+	}
+
+	warning = warningEnv
+	critical = criticalEnv
+	cooldown = cooldownEnv
+}
+
+// envVarToUint64 converts the environment variable into a uint64, in case of
+// error provided default value(def) is returned instead.
+func envVarToUint64(name string, def uint64) uint64 {
+	asString := os.Getenv(name)
+	if asString == "" {
+		return def
+	}
+
+	val, err := strconv.ParseUint(asString, 10, 64)
+	if err != nil {
+		return def
+	}
+
+	return val
 }
 
 func getOsProcesses() ([]proc.Process, error) {

--- a/cmd/oomhero/main_test.go
+++ b/cmd/oomhero/main_test.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	testTicker = make(chan time.Time)
+	now        = time.Now()
 )
 
 func TestNoOp(t *testing.T) {
@@ -32,7 +33,7 @@ func TestNoOp(t *testing.T) {
 func TestSingleWarningReceivedDuringCooldown(t *testing.T) {
 	t.Cleanup(resetState)
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = warning + 1
@@ -52,7 +53,7 @@ func TestSingleWarningReceivedDuringCooldown(t *testing.T) {
 func TestNextWarningReceivedAsCooldownElapses(t *testing.T) {
 	t.Cleanup(resetState)
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = warning + 1
@@ -63,7 +64,7 @@ func TestNextWarningReceivedAsCooldownElapses(t *testing.T) {
 
 	go watchProcesses(testTicker, ps.getProcesses)
 
-	tickXTimes(int(cooldown) + 1)
+	tickXTimes(61)
 
 	assert.Equal(t, 2, len(p.receivedSignals))
 	assert.Equal(t, syscall.SIGUSR1, p.receivedSignals[0])
@@ -91,7 +92,7 @@ func TestMultipleWarningReceivedWithDefaultCooldown(t *testing.T) {
 func TestSingleCriticalReceivedDuringCooldown(t *testing.T) {
 	t.Cleanup(resetState)
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = critical + 1
@@ -111,7 +112,7 @@ func TestSingleCriticalReceivedDuringCooldown(t *testing.T) {
 func TestNextCriticalReceivedAsCooldownElapses(t *testing.T) {
 	t.Cleanup(resetState)
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = critical + 1
@@ -122,7 +123,7 @@ func TestNextCriticalReceivedAsCooldownElapses(t *testing.T) {
 
 	go watchProcesses(testTicker, ps.getProcesses)
 
-	tickXTimes(int(cooldown) + 1)
+	tickXTimes(61)
 
 	assert.Equal(t, 2, len(p.receivedSignals))
 	assert.Equal(t, syscall.SIGUSR2, p.receivedSignals[0])
@@ -150,7 +151,7 @@ func TestMultipleCriticalReceivedWithDefaultCooldown(t *testing.T) {
 func TestSingleCriticalAndWarningReceivedAsMemoryUsageGrowsDuringCooldown(t *testing.T) {
 	t.Cleanup(resetState)
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = 0
@@ -177,7 +178,7 @@ func TestSingleCriticalAndWarningReceivedAsMemoryUsageGrowsDuringCooldown(t *tes
 func TestSingleWarningReceivedWhenMemoryUsageOscilatesDuringCooldown(t *testing.T) {
 	t.Cleanup(resetState)
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = warning - 1
@@ -235,7 +236,7 @@ func TestMultipleWarningReceivedWhenMemoryUsageOscilatesWithDefaultCooldown(t *t
 func TestSingleCriticalAndWarningReceivedWhenMemoryUsageOscilatesDuringCooldown(t *testing.T) {
 	t.Cleanup(resetState)
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = critical - 1
@@ -296,7 +297,7 @@ func TestWarningSignalEnvSettingIsRespected(t *testing.T) {
 	t.Cleanup(resetState)
 	t.Setenv("WARNING_SIGNAL", "SIGTERM")
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = warning + 1
@@ -317,7 +318,7 @@ func TestCriticalSignalEnvSettingIsRespected(t *testing.T) {
 	t.Cleanup(resetState)
 	t.Setenv("CRITICAL_SIGNAL", "SIGTERM")
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	p.memoryUsage = critical + 1
@@ -338,7 +339,7 @@ func TestWarningEnvSettingIsRespected(t *testing.T) {
 	t.Cleanup(resetState)
 	t.Setenv("WARNING", "42")
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	ps := TestProcesses{
@@ -368,7 +369,7 @@ func TestCriticalEnvSettingIsRespected(t *testing.T) {
 	t.Setenv("WARNING", "42")
 	t.Setenv("CRITICAL", "56")
 
-	cooldown = 60
+	cooldown = 60 * time.Second
 
 	p := newTestProcess(1)
 	ps := TestProcesses{
@@ -396,14 +397,42 @@ func TestCriticalEnvSettingIsRespected(t *testing.T) {
 	assert.Equal(t, syscall.SIGUSR2, p.receivedSignals[1])
 }
 
+func TestCooldownEnvSettingIsRespected(t *testing.T) {
+	t.Cleanup(resetState)
+	t.Setenv("COOLDOWN", "1m1s")
+
+	p := newTestProcess(1)
+	ps := TestProcesses{
+		items: []proc.Process{&p},
+	}
+
+	p.memoryUsage = warning + 1
+
+	go watchProcesses(testTicker, ps.getProcesses)
+
+	tickXTimes(1)
+
+	assert.Equal(t, 1, len(p.receivedSignals))
+	assert.Equal(t, syscall.SIGUSR1, p.receivedSignals[0])
+
+	tickXTimes(59)
+
+	assert.Equal(t, 1, len(p.receivedSignals))
+
+	tickXTimes(2)
+
+	assert.Equal(t, 2, len(p.receivedSignals))
+	assert.Equal(t, syscall.SIGUSR1, p.receivedSignals[0])
+	assert.Equal(t, syscall.SIGUSR1, p.receivedSignals[1])
+}
+
 func resetState() {
-	cooldown = 1
+	cooldown = 1 * time.Second
 	close(testTicker)
 	testTicker = make(chan time.Time)
 }
 
 func tickXTimes(n int) {
-	now := time.Now()
 	for i := 0; i < n; i++ {
 		testTicker <- now
 		time.Sleep(50 * time.Millisecond) // let the other gorutine do its things


### PR DESCRIPTION
This pull request migrates the COOLDOWN environment variable to a format understood by `time.ParseDuartion`.
What is more, migration is done in backward-compatible mode (COOLDOWN equal to a number of seconds w/o unit would still be understood).

Additionally, tests are added.