### PR TITLE
change V2 fallback to not require privileged host access

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ spec:
       image: quay.io/rmarasch/oomhero:latest
       imagePullPolicy: Always
       securityContext:
-        privileged: true
+        capabilities:
+          add:
+          - SYS_PTRACE
       env:
       - name: WARNING
         value: "65"
@@ -137,10 +139,3 @@ containers:
     - name: COOLDOWN
       value: "1m30s"
 ```
-
-### Help needed
-
-[Official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/)
-states that `SYS_PTRACE` capability is mandatory when signaling between containers
-on the same Pod. I could not validate if this is true as it works without it on my
-K8S cluster. If to make it work you had to add this capability please let me know.

--- a/mem/mem.go
+++ b/mem/mem.go
@@ -3,7 +3,6 @@ package mem
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 )
@@ -11,6 +10,8 @@ import (
 var (
 	limitSuffixPathCgroupV1 = "sys/fs/cgroup/memory/memory.limit_in_bytes"
 	usageSuffixPathCgroupV1 = "sys/fs/cgroup/memory/memory.usage_in_bytes"
+	limitSuffixPathCgroupV2 = "sys/fs/cgroup/memory.max"
+	usageSuffixPathCgroupV2 = "sys/fs/cgroup/memory.current"
 )
 
 // LimitAndUsageForProc returns memory limit and usage for cgroup where proc
@@ -34,17 +35,8 @@ func LimitForProc(proc *os.Process) (uint64, error) {
 	if val, err := readBytesFromFile(limitFile); err == nil {
 		return val, nil
 	}
-	path, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", proc.Pid))
-	if err != nil {
-		return 0, err
-	}
-	pbegin := bytes.IndexByte(path, '/')
-	if pbegin == -1 {
-		return 0, fmt.Errorf("invalid cgroup path: %s", path)
-	}
-	path = bytes.TrimSpace(path[pbegin:])
-	spath := fmt.Sprintf("/sys/fs/cgroup/%s/memory.max", string(path))
-	return readBytesFromFile(spath)
+	limitFile = fmt.Sprintf("/proc/%d/root/%s", proc.Pid, limitSuffixPathCgroupV2)
+	return readBytesFromFile(limitFile)
 }
 
 // UsageForProc returns the amount of memory currently in use within the namespace
@@ -54,23 +46,14 @@ func UsageForProc(proc *os.Process) (uint64, error) {
 	if val, err := readBytesFromFile(usageFile); err == nil {
 		return val, nil
 	}
-	path, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", proc.Pid))
-	if err != nil {
-		return 0, err
-	}
-	pbegin := bytes.IndexByte(path, '/')
-	if pbegin == -1 {
-		return 0, fmt.Errorf("invalid cgroup path: %s", path)
-	}
-	path = bytes.TrimSpace(path[pbegin:])
-	spath := fmt.Sprintf("/sys/fs/cgroup/%s/memory.current", string(path))
-	return readBytesFromFile(spath)
+	usageFile = fmt.Sprintf("/proc/%d/root/%s", proc.Pid, usageSuffixPathCgroupV2)
+	return readBytesFromFile(usageFile)
 }
 
 // readBytesFromFile reads a file and returns its content as a uint64. if the string
 // "max" is found, this returns 0.
 func readBytesFromFile(fpath string) (uint64, error) {
-	content, err := ioutil.ReadFile(fpath)
+	content, err := os.ReadFile(fpath)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
OOMHero is meant to run as a k8s sidecar and only manage other containers within the same Pod/shared process namespace, so there's little reason it should require privileged host access.

This PR updates the path for the V2 fallback to use `/proc/<pid>/root/sys/fs/cgroup/`, similar to the V1 pattern. With this change, reading PID 1 will fail but PID 1 will always be the pause container which we don't care about.