### PR TITLE
chore: increase default interval to 100ms

### DIFF
--- a/v2/Containerfile
+++ b/v2/Containerfile
@@ -3,7 +3,7 @@ RUN apt update -y
 RUN apt install make -y
 WORKDIR /oomhero
 COPY . .
-RUN make build
+RUN make release
 
 FROM docker.io/debian:trixie-slim
 COPY --from=builder /oomhero/target/release/oomhero /usr/local/bin/oomhero

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -1,14 +1,20 @@
+IMAGE ?= docker.io/ricardomaraschini/oomhero:v2
+
 .PHONY: build
 build:
+	cargo build
+
+.PHONY: release
+release:
 	cargo build --release
 
 .PHONY: image-build
 image-build:
-	docker build -t docker.io/ricardomaraschini/oomhero:v2 -f Containerfile .
+	docker build -t $(IMAGE) -f Containerfile .
 
 .PHONY: image-push
 image-push:
-	docker push docker.io/ricardomaraschini/oomhero:v2
+	docker push $(IMAGE)
 
 .PHONY: image-build-push
 image-build-push: image-build image-push

--- a/v2/README.md
+++ b/v2/README.md
@@ -62,9 +62,6 @@ spec:
         cpu: "250m"
   - name: oomhero
     image: docker.io/ricardomaraschini/oomhero:v2
-    env:
-    - name: RUST_LOG
-      value: info
     resources:
       limits:
         cpu: "1m"
@@ -77,12 +74,12 @@ spec:
 
 ## Usage
 ```bash
-oomhero --warning 75 --critical 90 --interval 10ms
+oomhero --warning 75 --critical 90 --interval 200ms
 ```
 **Options:**
 - `--warning <N>` - Warning threshold % (default: 75)
 - `--critical <N>` - Critical threshold % (default: 90)
-- `--interval <DURATION>` - Scan interval (default: 10ms)
+- `--interval <DURATION>` - Scan interval (default: 100ms)
 
 **Environment:**
 - `RUST_LOG=info` - Log level (debug, info, warn, error)
@@ -137,9 +134,9 @@ spec:
 
 > [!IMPORTANT]
 > The scan loop runs continuously at `--interval` rate, the default is to run a
-> full scan every 10ms making it **very** aggressive with regards to CPU usage,
-> this is by design. You can adjust the interval by setting proper
-> `resource.limits.cpu` values for the container **OR** by passing a custom
+> full scan every 100ms making it **very** aggressive with regards to CPU usage,
+> this is by design. You can either adjust the interval by setting and adequate
+> `resource.limits.cpu` value for the container **OR** by passing a custom
 > `--interval` flag.
 
 ## Requirements

--- a/v2/manifests/deployment_test.yaml
+++ b/v2/manifests/deployment_test.yaml
@@ -27,11 +27,6 @@ spec:
   - name: oomhero
     image: docker.io/ricardomaraschini/oomhero:v2
     imagePullPolicy: Always
-    args:
-    - --cooldown=10ms
-    env:
-    - name: RUST_LOG
-      value: info
     resources:
       limits:
         cpu: "1m"

--- a/v2/src/main.rs
+++ b/v2/src/main.rs
@@ -24,7 +24,7 @@ struct Arguments {
     #[arg(long, default_value = "90", help = "Critical memory usage watermark")]
     critical: i32,
 
-    #[arg(long, default_value = "10ms", help = "How often scan all processes", value_parser = parse_duration)]
+    #[arg(long, default_value = "100ms", help = "How often scan all processes", value_parser = parse_duration)]
     interval: time::Duration,
 
     #[arg(long, default_value = "30s", help = "Interval between signals", value_parser = parse_duration)]
@@ -35,9 +35,12 @@ struct Arguments {
 
     #[arg(long, default_value = "SIGUSR2", help = "Signal send on critical")]
     critical_signal: signal::Signal,
+
+    #[arg(long, default_value = "false", help = "Print version")]
+    version: bool,
 }
 
-const VERSION: &str = "2.0.0";
+const VERSION: &str = "2.0.0-alpha";
 
 // parse_duration is used to parse the interval command line flag.
 fn parse_duration(s: &str) -> Result<time::Duration, String> {
@@ -83,6 +86,11 @@ fn main() {
 
     env_logger::init();
     let mut args = Arguments::parse();
+    if args.version {
+        println!("oomhero version v{VERSION}");
+        return;
+    }
+
     environment_overwrites(&mut args);
     print_welcome(&args);
 


### PR DESCRIPTION
using 10ms was way too agressive on my tests so i am increasing it to 100ms. it is still customizable through --interval.

this commit also adds a --version flag and addresses some small things with regards to documentation.