### PR TITLE
chore: generate a smaller release binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,8 @@ futures-util = "0.3.32"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1


### PR DESCRIPTION
binary was over 7MB, by stripping and allowing the compiler to be smarter we now have a binary of 4MB.