### PR TITLE
test: adding end to end test for io pressure

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,9 +11,7 @@ jobs:
     steps:
     - name: check out code
       uses: actions/checkout@v6
-    - name: setup podman socket
-      run: systemctl --user start podman.socket
     - name: run lint
       run: make lint
     - name: run tests
-      run: make test-verbose
+      run: make test-verbose-as-root

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
  "signal-hook",
  "thiserror 2.0.18",
  "tokio",
+ "users",
  "vergen-git2",
 ]
 
@@ -1694,7 +1695,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1731,7 +1732,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2545,6 +2546,16 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ futures-util = "0.3.32"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+users = "0.11"
 
 [profile.release]
 strip = true

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,13 @@ test-verbose: test-workload-image-build image-build
 .PHONY: test-workload-image-build
 test-workload-image-build:
 	podman build -t test-workload tests/workload
+
+# the next recipe is tailored to run things as root. this should not be
+# needed locally but is paramount for running the full end to end tests.
+# the runner does not have cargo installed for the root user, this is
+# a hack. we build the  needed images and then run the tests.
+.PHONY: test-verbose-as-root
+test-verbose-as-root:
+	sudo podman build -t test-workload tests/workload
+	sudo podman build -t $(IMAGEFULL) .
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="sudo" timeout 5m cargo test -- --nocapture

--- a/tests/end_2_end.rs
+++ b/tests/end_2_end.rs
@@ -1,12 +1,18 @@
-use podman_api::Podman;
+use nix::sys::stat;
+use podman_api::models::LinuxBlockIo;
 use podman_api::models::LinuxCpu;
 use podman_api::models::LinuxMemory;
 use podman_api::models::LinuxResources;
+use podman_api::models::LinuxThrottleDevice;
 use podman_api::models::PortMapping;
 use podman_api::opts;
+use podman_api::Podman;
 use serde::Deserialize;
 use std::env;
+use std::fs;
+use std::path::Path;
 use std::time::Duration;
+use users::get_current_uid;
 
 // WORKLOAD_IMAGE is the image that simulates an actual workload on a cluster. It is the
 // application that is monitored by the oomhero container, receives signals and  reacts
@@ -25,74 +31,168 @@ struct Stats {
     signals_received: i32,
 }
 
-// WORKLOAD_CONTAINER_RESOURCE_LIMITS limits the amount of resources that the test workload
-// container can use.
-const WORKLOAD_CONTAINER_RESOURCE_LIMITS: LinuxResources = LinuxResources {
-    cpu: Some(LinuxCpu {
-        period: Some(1_000_000),
-        quota: Some(100_000),
-        cpus: None,
-        mems: None,
-        realtime_period: None,
-        realtime_runtime: None,
-        shares: None,
-    }),
-    memory: Some(LinuxMemory {
-        limit: Some(67_108_864),
-        disable_oom_killer: None,
-        kernel: None,
-        kernel_tcp: None,
-        reservation: None,
-        swap: None,
-        swappiness: None,
-        use_hierarchy: None,
-    }),
-    block_io: None,
-    devices: None,
-    hugepage_limits: None,
-    network: None,
-    pids: None,
-    rdma: None,
-    unified: None,
-};
+// workload_container_resource_limits  returns the limits to be used in the workload
+// container. We limit the amount of resources that the test workload container can
+// use to make testing easier.
+async fn workload_container_resource_limits() -> LinuxResources {
+    let mut limits = LinuxResources {
+        cpu: Some(LinuxCpu {
+            period: Some(1_000_000),
+            quota: Some(100_000),
+            cpus: None,
+            mems: None,
+            realtime_period: None,
+            realtime_runtime: None,
+            shares: None,
+        }),
+        memory: Some(LinuxMemory {
+            limit: Some(67_108_864),
+            disable_oom_killer: None,
+            kernel: None,
+            kernel_tcp: None,
+            reservation: None,
+            swap: None,
+            swappiness: None,
+            use_hierarchy: None,
+        }),
+        block_io: None,
+        devices: None,
+        hugepage_limits: None,
+        network: None,
+        pids: None,
+        rdma: None,
+        unified: None,
+    };
 
-// OOMHERO_CONTAINER_RESOURCE_LIMITS limits the amount of resources our test oomhero container can
-// use during the test execution.
-const OOMHERO_CONTAINER_RESOURCE_LIMITS: LinuxResources = LinuxResources {
-    cpu: Some(LinuxCpu {
-        period: Some(1_000_000),
-        quota: Some(100_000),
-        cpus: None,
-        mems: None,
-        realtime_period: None,
-        realtime_runtime: None,
-        shares: None,
-    }),
-    memory: Some(LinuxMemory {
-        limit: Some(33_554_432),
-        disable_oom_killer: None,
-        kernel: None,
-        kernel_tcp: None,
-        reservation: None,
-        swap: None,
-        swappiness: None,
-        use_hierarchy: None,
-    }),
-    block_io: None,
-    devices: None,
-    hugepage_limits: None,
-    network: None,
-    pids: None,
-    rdma: None,
-    unified: None,
-};
+    // we only ingest io limits if the controller is enabled. if the user is using
+    // root to run the tests then this is most likely be enabled. systemd does not
+    // delegate the io controller to regular users.
+    if io_controller_is_enabled().await {
+        let (major, minor) = major_and_minor_numbers_for_podman_storage().await;
+        limits.block_io = Some(LinuxBlockIo {
+            throttle_write_iops_device: Some(vec![LinuxThrottleDevice {
+                major: Some(major as i64),
+                minor: Some(minor as i64),
+                rate: Some(100),
+            }]),
+            leaf_weight: None,
+            throttle_read_bps_device: None,
+            throttle_read_iops_device: None,
+            throttle_write_bps_device: None,
+            weight: None,
+            weight_device: None,
+        });
+    }
+
+    limits
+}
+
+// major_and_minor_numbers_for_podman_storage finds out the device driver major and minor numbers
+// for the device in which the containers have their temporary storage mounted. The container is
+// then expected to execute io on this device, we can then restrict it.
+async fn major_and_minor_numbers_for_podman_storage() -> (u64, u64) {
+    let client = podman_client();
+    let info = client
+        .info()
+        .await
+        .expect("failed to read podman information");
+
+    let path = info.store.unwrap().graph_root.unwrap();
+    let device = stat::stat(path.as_str()).expect("failed to stat podman storage fs");
+    let major = stat::major(device.st_dev);
+    let minor = stat::minor(device.st_dev);
+
+    // if this device is a partition we need to search for the parent device as we can't impose
+    // io limits directly on the partition.
+    if let Some(parent_data) = major_and_minor_numbers_for_parent(major, minor) {
+        parent_data
+    } else {
+        (major, minor)
+    }
+}
+
+// major_and_minor_numbers_for_parent returns the major and minor numbers for the device who is
+// parent of the device identified by the provided major and minor. this is used to identify
+// what is the disk in which a given partition is, we can't impose io limits in a partition, we
+// need to impose on the whole disk.
+fn major_and_minor_numbers_for_parent(major: u64, minor: u64) -> Option<(u64, u64)> {
+    let partition_file = format!("/sys/dev/block/{}:{}/partition", major, minor);
+    if !Path::new(&partition_file).exists() {
+        return None;
+    }
+
+    let dev_file = format!("/sys/dev/block/{}:{}/../dev", major, minor);
+    let dev = fs::read_to_string(&dev_file).expect("failed to read dev file");
+
+    // format is <major>:<minor>
+    let parts: Vec<&str> = dev.trim().split(':').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+
+    let major: u64 = parts[0].parse().expect("failed to parse major number");
+    let minor: u64 = parts[1].parse().expect("failed to parse minor number");
+    Some((major, minor))
+}
+
+// oomhero_container_resource_limits returns the container limits to be applied to the oomhero
+// container during tests.
+fn oomhero_container_resource_limits() -> LinuxResources {
+    LinuxResources {
+        cpu: Some(LinuxCpu {
+            period: Some(1_000_000),
+            quota: Some(100_000),
+            cpus: None,
+            mems: None,
+            realtime_period: None,
+            realtime_runtime: None,
+            shares: None,
+        }),
+        memory: Some(LinuxMemory {
+            limit: Some(33_554_432),
+            disable_oom_killer: None,
+            kernel: None,
+            kernel_tcp: None,
+            reservation: None,
+            swap: None,
+            swappiness: None,
+            use_hierarchy: None,
+        }),
+        block_io: None,
+        devices: None,
+        hugepage_limits: None,
+        network: None,
+        pids: None,
+        rdma: None,
+        unified: None,
+    }
+}
 
 // podman_client returns a client pointing to the podman socket. The socket is expected to be under
-// $XDG_RUNTIME_DIR/podman/podman.sock.
+// $XDG_RUNTIME_DIR/podman/podman.sock for regular users while for root we use the socket under
+// /run/podman/podman.sock. This test can be ran as either root or regular user but the full
+// coverage can only be achieved with root (systemd does not delegate some cgroup controllers to
+// regular users).
 fn podman_client() -> Podman {
+    if get_current_uid() == 0 {
+        return Podman::unix("/run/podman/podman.sock");
+    }
     let runtime_dir = env::var("XDG_RUNTIME_DIR").expect("failed to read xdg runtime dir");
     let socket_path = format!("{}/podman/podman.sock", runtime_dir);
     Podman::unix(socket_path)
+}
+
+// io_controller_is_enabled returns true if the io controller is enabled. if it is disabled then
+// some of the tests aren't going to run. if you are running the tests as root then you probably
+// have it enabled (systemd does not delegate it to regular users though).
+async fn io_controller_is_enabled() -> bool {
+    let client = podman_client();
+    let info = client
+        .info()
+        .await
+        .expect("failed to read podman information");
+    let controllers = info.host.unwrap().cgroup_controllers.unwrap();
+    controllers.contains(&"io".to_string())
 }
 
 // create_test_pod will create a pod with three containers, one with the pause image, one with the
@@ -131,14 +231,14 @@ async fn create_test_pod(name: String, arguments: &Vec<&str>) {
     let workload_container_create_opts = &opts::ContainerCreateOpts::builder()
         .name("workload")
         .pod(name.clone())
-        .resource_limits(WORKLOAD_CONTAINER_RESOURCE_LIMITS)
+        .resource_limits(workload_container_resource_limits().await)
         .image(WORKLOAD_IMAGE)
         .build();
 
     let oomhero_container_create_opts = &opts::ContainerCreateOpts::builder()
         .name("oomhero")
         .pod(name.clone())
-        .resource_limits(OOMHERO_CONTAINER_RESOURCE_LIMITS)
+        .resource_limits(oomhero_container_resource_limits())
         .add_capabilities(vec!["SYS_PTRACE"])
         .image(OOMHERO_IMAGE)
         .command(arguments)
@@ -169,7 +269,7 @@ async fn create_test_pod(name: String, arguments: &Vec<&str>) {
 // are ignored.
 async fn attempt_test_pod_removal(name: String) {
     let pod = podman_client().pods().get(name);
-    _ = pod.stop().await;
+    _ = pod.kill().await;
     _ = pod.remove().await;
 }
 
@@ -184,6 +284,13 @@ async fn end_2_end() {
     // just in case we had a pod running from a failed previous attempt.
     attempt_test_pod_removal(String::from("oomhero_test_pod")).await;
 
+    if !io_controller_is_enabled().await {
+        println!("*****************************************************************");
+        println!("* IO TESTS WILL BE SKIPPED BECAUSE THE CONTROLLER ISN'T ENABLED *");
+        println!("* YOU MAY WANT TO RUN THIS TEST AS ROOT OR JUST DELEGATE TO CI  *");
+        println!("*****************************************************************");
+    }
+
     // create the pod with the two containers (three if we count the pause container). oomhero
     // is configured to warning on 80% and 90% for both memory usage and cpu pressure. Once
     // this call is back we know that the container is up and running;
@@ -195,6 +302,8 @@ async fn end_2_end() {
             "--memory-usage-critical=90",
             "--cpu-pressure-warning=80",
             "--cpu-pressure-critical=90",
+            "--io-pressure-warning=50",
+            "--io-pressure-critical=80",
         ],
     )
     .await;
@@ -216,7 +325,7 @@ async fn end_2_end() {
     println!("test workload informs that the cpu signal has been received");
 
     // we just wait a little bit before starting up the next test, memory consumption.
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // we now rinse and repeat but this time assessing memory consumption.
     println!("informing the test workload to start eating memory");
@@ -229,6 +338,26 @@ async fn end_2_end() {
     println!("waiting for the test workload to receive the second signal (mem usage)");
     wait_for_signals(&client, 2).await;
     println!("test workload informs that the memory signal has been received");
+
+    if !io_controller_is_enabled().await {
+        attempt_test_pod_removal(String::from("oomhero_test_pod")).await;
+        return;
+    }
+
+    // we just wait a little bit before starting up the next test, io consumption.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // we now rinse and repeat but this time assessing memory consumption.
+    println!("informing the test workload to start doing io");
+    client
+        .get("http://localhost:9999/io")
+        .send()
+        .await
+        .expect("failed to send /io request");
+
+    println!("waiting for the test workload to receive the third signal (io usage)");
+    wait_for_signals(&client, 3).await;
+    println!("test workload informs that the io signal has been received");
 
     attempt_test_pod_removal(String::from("oomhero_test_pod")).await;
 }

--- a/tests/workload/Cargo.lock
+++ b/tests/workload/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +99,18 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -129,6 +153,40 @@ dependencies = [
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -211,16 +269,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -308,6 +396,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,12 +424,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -345,6 +462,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -472,6 +595,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,10 +690,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -575,12 +769,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "workload"
 version = "0.1.0"
 dependencies = [
  "axum",
  "serde",
  "signal-hook",
+ "tempfile",
  "tokio",
 ]
 

--- a/tests/workload/Cargo.toml
+++ b/tests/workload/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 axum = "0.8.9"
 serde = { version = "1.0.228", features = ["derive"] }
 signal-hook = "0.4.4"
+tempfile = "3.27.0"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/tests/workload/src/main.rs
+++ b/tests/workload/src/main.rs
@@ -6,11 +6,15 @@ use serde::Serialize;
 use signal_hook::consts::SIGUSR1;
 use signal_hook::consts::SIGUSR2;
 use signal_hook::iterator::Signals;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::mpsc;
 use std::thread;
 use std::time;
+use tempfile::tempfile;
 
 #[derive(Clone)]
 struct AppState {
@@ -18,13 +22,13 @@ struct AppState {
     cpu_next: Arc<Mutex<bool>>,
     mem_tx: mpsc::SyncSender<bool>,
     mem_next: Arc<Mutex<bool>>,
+    io_tx: mpsc::SyncSender<bool>,
+    io_next: Arc<Mutex<bool>>,
     signals_received: Arc<Mutex<i32>>,
 }
 
 #[derive(Serialize)]
 struct Stats {
-    cpu_next: bool,
-    mem_next: bool,
     signals_received: i32,
 }
 
@@ -36,11 +40,16 @@ async fn main() {
     let (mem_tx, mem_rx) = mpsc::sync_channel::<bool>(1);
     thread::spawn(move || mem_usage(mem_rx));
 
+    let (io_tx, io_rx) = mpsc::sync_channel::<bool>(1);
+    thread::spawn(move || io_usage(io_rx));
+
     let state = AppState {
         cpu_tx: cpu_tx.clone(),
         cpu_next: Arc::new(Mutex::new(true)),
         mem_tx: mem_tx.clone(),
         mem_next: Arc::new(Mutex::new(true)),
+        io_tx: io_tx.clone(),
+        io_next: Arc::new(Mutex::new(true)),
         signals_received: Arc::new(Mutex::new(0)),
     };
 
@@ -50,6 +59,7 @@ async fn main() {
     let router = Router::new()
         .route("/cpu", get(cpu_handler))
         .route("/mem", get(mem_handler))
+        .route("/io", get(io_handler))
         .route("/stats", get(stats_handler))
         .with_state(state);
 
@@ -86,10 +96,17 @@ fn signal_handler(state: AppState) {
 // memory switches (if pressed) and the amount of signals received.
 async fn stats_handler(State(state): State<AppState>) -> Json<Stats> {
     Json(Stats {
-        cpu_next: *state.cpu_next.lock().unwrap(),
-        mem_next: *state.mem_next.lock().unwrap(),
         signals_received: *state.signals_received.lock().unwrap(),
     })
+}
+
+// io_handler flips the io consumption on and off. One call turns it on, the next turns it off.
+async fn io_handler(State(state): State<AppState>) -> &'static str {
+    println!("io switch pressed");
+    let mut next = state.io_next.lock().unwrap();
+    state.io_tx.send(*next).expect("failed sending message");
+    *next = !*next;
+    "io ack"
 }
 
 // cpu_handler flips the cpu consumption on and off. One call turns it on, the next turns it off.
@@ -111,8 +128,8 @@ async fn mem_handler(State(state): State<AppState>) -> &'static str {
 }
 
 // mem_usage is a loop that may or may not increase the memory consumption in the workload process.
-// If a true value is read from the Receiver then we start to consume 2MB of memory per second. If
-// a false is read instead then we truncate the used memory to 0.
+// If a true value is read from the Receiver then we start to consume 1.5MB of memory per second.
+// If a false is read instead then we truncate the used memory to 0.
 fn mem_usage(switch: mpsc::Receiver<bool>) {
     let mut previous: bool = false;
     let mut ballast: Vec<String> = Vec::new();
@@ -124,12 +141,66 @@ fn mem_usage(switch: mpsc::Receiver<bool>) {
         };
 
         match consume {
-            true => ballast.push("x".repeat(2 * 1_024 * 1_024)),
+            true => ballast.push("x".repeat(1_572_864)),
             false => ballast.truncate(0),
         }
 
         previous = consume;
         thread::sleep(delay);
+    }
+}
+
+// io_usage creates io activity when true is received on the channel. False causes it to stop.
+// This function increases the amount of IOPs done each 10 seconds as the average is taking out
+// of the 10 seconds. The values presented below are based on the test limit (100iops).
+fn io_usage(switch: mpsc::Receiver<bool>) {
+    let mut fp = tempfile().expect("failed to create temp file");
+    let mut previous = false;
+    let data = vec![0u8; 4096];
+    let mut iterations = 0;
+    let sleep_time = time::Duration::from_millis(100);
+
+    // the batch size increases as the amount of iterations increases. this is useful to get
+    // a constant and growing number of iops. we want to avoid the scenario 0% to 100% io
+    // pressure so as we iterate so grows the batch of writes we do.
+    let batch_size = |iterations: u128| match iterations / sleep_time.as_millis() {
+        0 => 10,
+        1 => 20,
+        2 => 30,
+        3 => 40,
+        4 => 50,
+        5 => 60,
+        6 => 70,
+        _ => 100,
+    };
+
+    // write_to_temp_file writes `size` 4kb chunks of empty data to the temp file pointed by fp.
+    // it then seeks the file back to its start so subsequent calls don't increase the file size.
+    let mut write_to_temp_file = move |size: i32| {
+        for _ in 0..size {
+            fp.write_all(&data).expect("failed to write");
+            fp.sync_all().expect("failed to sync");
+            fp.seek(SeekFrom::Start(0)).expect("failed to seek");
+        }
+    };
+
+    loop {
+        let mut active = previous;
+        if let Ok(value) = switch.try_recv() {
+            active = value;
+        }
+
+        let (new_iterations, sleep) = match active {
+            false => (0, time::Duration::from_secs(1)),
+            true => {
+                write_to_temp_file(batch_size(iterations));
+                (iterations + 1, sleep_time)
+            }
+        };
+
+        iterations = new_iterations;
+        previous = active;
+        thread::sleep(sleep);
     }
 }
 


### PR DESCRIPTION
this one took me for a ride. systemd does not delegate the "io" cgroup controller to the user so we can't test io as regular users, we need to be root. that is unfortunate. there is a workaround (configure systemd to delegate) but it is an uphill battle i don't want to go through.

if you run the e2e as root you will have io pressure tests, if not then you won't. a message is printed though. the idea is to guarantee that the ci runs as root so we will have this tested before merge anyways.

to figure out a "close to deterministic" way of ramping up io usage was another interesting task. what a night i had, this is getting together.