### PR TITLE
bug: general reassessment of units in use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oomhero"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "clap",
  "duration-str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oomhero"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 
 [build-dependencies]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -59,7 +59,7 @@ impl Server {
             ("avg10", d.avg10),
             ("avg60", d.avg60),
             ("avg300", d.avg300),
-            ("total", d.total),
+            ("total", d.total as f32),
         ];
         for (window, value) in severity_windows {
             let labels = [

--- a/src/processes.rs
+++ b/src/processes.rs
@@ -48,7 +48,7 @@ pub struct PressureAverages {
     pub avg10: f32,
     pub avg60: f32,
     pub avg300: f32,
-    pub total: f32,
+    pub total: u64,
 }
 
 impl PartialEq for PressureAverages {
@@ -66,8 +66,8 @@ impl PartialEq for PressureAverages {
 // we also keep track of the process memory usage (%) and the oom_score.
 #[derive(Debug, Default, Clone)]
 pub struct CollectedData {
-    pub memory_max: f32,
-    pub memory_current: f32,
+    pub memory_max: u64,
+    pub memory_current: u64,
     pub oom_score: i32,
     pub pressure: Pressure,
 }
@@ -75,8 +75,8 @@ pub struct CollectedData {
 impl CollectedData {
     // memory_usage returns the memory in use as percentage.
     pub fn memory_usage(&self) -> f32 {
-        if self.memory_max > 0. {
-            self.memory_current / self.memory_max * 100.
+        if self.memory_max > 0 {
+            self.memory_current as f32 / self.memory_max as f32 * 100.
         } else {
             0.
         }
@@ -180,12 +180,12 @@ impl<T: system::Provider> ProcFsReader<T> {
     // memory_stats returns stats about memory utilization for the provided process id. Values are
     // returned as a tuple where the first element is the current memory utilization and the second
     // the maximum allowed. This data is read from the cgroup's /proc files.
-    fn memory_stats(&self, pid: i32) -> Result<(f32, f32), Error> {
+    fn memory_stats(&self, pid: i32) -> Result<(u64, u64), Error> {
         let path = self.system.path_to_memory_max(pid)?;
-        let memory_max: f32 = fs::read_to_string(path)?.trim().parse()?;
+        let memory_max: u64 = fs::read_to_string(path)?.trim().parse()?;
 
         let path = self.system.path_to_memory_current(pid)?;
-        let memory_current: f32 = fs::read_to_string(path)?.trim().parse()?;
+        let memory_current: u64 = fs::read_to_string(path)?.trim().parse()?;
 
         Ok((memory_current, memory_max))
     }
@@ -194,7 +194,7 @@ impl<T: system::Provider> ProcFsReader<T> {
     // can use. Kernel sets the limit to the string 'max' if no upper limit is set.
     fn has_memory_limit(&self, pid: i32) -> Result<bool, Error> {
         let path = self.system.path_to_memory_max(pid)?;
-        Ok(fs::read_to_string(path)?.trim().parse::<i128>().is_ok())
+        Ok(fs::read_to_string(path)?.trim().parse::<u64>().is_ok())
     }
 
     // oom_score returns the oom score for a given pid. The score is calculated by reading the

--- a/tests/daemons_run.rs
+++ b/tests/daemons_run.rs
@@ -37,8 +37,8 @@ fn daemons_run_processes_cooldown_enforcement() -> Result<(), errors::Error> {
         .with(predicate::eq(2))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 95.,
+                memory_max: 100,
+                memory_current: 95,
                 ..Default::default()
             })
         });
@@ -114,8 +114,8 @@ fn daemons_run_processes_exclusion() -> Result<(), errors::Error> {
         .with(predicate::eq(2))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 80.,
+                memory_max: 100,
+                memory_current: 80,
                 oom_score: 0,
                 pressure: processes::Pressure::default(),
             })
@@ -190,7 +190,7 @@ fn daemons_run_processes_with_cpu_pressure_critical() -> Result<(), errors::Erro
                             avg10: 21.,
                             avg60: 0.,
                             avg300: 0.,
-                            total: 0.,
+                            total: 0,
                         },
                         ..Default::default()
                     },
@@ -250,8 +250,8 @@ fn daemons_run_processes_with_critical_but_only_pressure_thresholds() -> Result<
         .with(predicate::eq(2))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 91.,
+                memory_max: 100,
+                memory_current: 91,
                 oom_score: 0,
                 pressure: processes::Pressure {
                     ..Default::default()
@@ -307,8 +307,8 @@ fn daemons_run_processes_with_critical() -> Result<(), errors::Error> {
         .with(predicate::eq(2))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 91.,
+                memory_max: 100,
+                memory_current: 91,
                 oom_score: 0,
                 pressure: processes::Pressure {
                     ..Default::default()
@@ -377,7 +377,7 @@ fn daemons_run_processes_with_io_pressure_critical() -> Result<(), errors::Error
                             avg10: 21.,
                             avg60: 0.,
                             avg300: 0.,
-                            total: 0.,
+                            total: 0,
                         },
                         ..Default::default()
                     },
@@ -442,8 +442,8 @@ fn daemons_run_processes_with_memory_pressure_critical() -> Result<(), errors::E
         .with(predicate::eq(2))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 50.,
+                memory_max: 100,
+                memory_current: 50,
                 oom_score: 0,
                 pressure: processes::Pressure {
                     memory: processes::PressureData {
@@ -451,7 +451,7 @@ fn daemons_run_processes_with_memory_pressure_critical() -> Result<(), errors::E
                             avg10: 21.,
                             avg60: 0.,
                             avg300: 0.,
-                            total: 0.,
+                            total: 0,
                         },
                         ..Default::default()
                     },
@@ -517,8 +517,8 @@ fn daemons_run_processes_with_mixed_thresholds_critical_precedence() -> Result<(
         .with(predicate::eq(2))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 75., // Warning level for memory usage
+                memory_max: 100,
+                memory_current: 75, // Warning level for memory usage
                 oom_score: 0,
                 pressure: processes::Pressure {
                     memory: processes::PressureData {
@@ -526,7 +526,7 @@ fn daemons_run_processes_with_mixed_thresholds_critical_precedence() -> Result<(
                             avg10: 25., // Critical level for memory pressure
                             avg60: 0.,
                             avg300: 0.,
-                            total: 0.,
+                            total: 0,
                         },
                         ..Default::default()
                     },
@@ -589,8 +589,8 @@ fn daemons_run_processes_with_warning() -> Result<(), errors::Error> {
         .with(predicate::eq(2))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 75.,
+                memory_max: 100,
+                memory_current: 75,
                 oom_score: 0,
                 pressure: processes::Pressure {
                     ..Default::default()
@@ -648,8 +648,8 @@ fn daemons_run_processes_within_limits() -> Result<(), errors::Error> {
         .with(predicate::eq(2))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 10.,
+                memory_max: 100,
+                memory_current: 10,
                 oom_score: 0,
                 pressure: processes::Pressure {
                     ..Default::default()
@@ -662,8 +662,8 @@ fn daemons_run_processes_within_limits() -> Result<(), errors::Error> {
         .with(predicate::eq(3))
         .returning(|_pid| {
             Ok(processes::CollectedData {
-                memory_max: 100.,
-                memory_current: 20.,
+                memory_max: 100,
+                memory_current: 20,
                 oom_score: 0,
                 pressure: processes::Pressure {
                     ..Default::default()

--- a/tests/processes_collect_process_data.rs
+++ b/tests/processes_collect_process_data.rs
@@ -95,8 +95,8 @@ fn collect_process_data_unlimited_memory_process() -> Result<(), errors::Error> 
     let proc = processes::ProcFsReader::new(mock);
     let result = proc.collect_process_data(1)?;
     assert_eq!(result.oom_score, 0);
-    assert_eq!(result.memory_max, 0.);
-    assert_eq!(result.memory_current, 0.);
+    assert_eq!(result.memory_max, 0);
+    assert_eq!(result.memory_current, 0);
     assert_eq!(result.memory_usage(), 0.);
     Ok(())
 }
@@ -108,8 +108,8 @@ fn collect_process_data_10_pct_memory_usage() -> Result<(), errors::Error> {
     let proc = processes::ProcFsReader::new(mock);
     let result = proc.collect_process_data(1)?;
     assert_eq!(result.oom_score, 0);
-    assert_eq!(result.memory_max, 1000.);
-    assert_eq!(result.memory_current, 100.);
+    assert_eq!(result.memory_max, 1000);
+    assert_eq!(result.memory_current, 100);
     assert_eq!(result.memory_usage(), 10.);
     Ok(())
 }
@@ -130,7 +130,7 @@ fn collect_process_data_invalid_pressure_data() -> Result<(), errors::Error> {
     let mock = mock_for_fake_process(&proc_name);
     let proc = processes::ProcFsReader::new(mock);
     let result = proc.collect_process_data(1);
-    assert!(matches!(result, Err(errors::Error::ParseFloatError(_))));
+    assert!(matches!(result, Err(errors::Error::ParseIntError(_))));
     Ok(())
 }
 
@@ -147,13 +147,13 @@ fn collect_process_data_full_pressure_data() -> Result<(), errors::Error> {
                 avg10: 1.,
                 avg60: 2.,
                 avg300: 3.,
-                total: 4.,
+                total: 4,
             },
             full: processes::PressureAverages {
                 avg10: 5.,
                 avg60: 6.,
                 avg300: 7.,
-                total: 8.,
+                total: 8,
             },
         },
         io: processes::PressureData {
@@ -161,13 +161,13 @@ fn collect_process_data_full_pressure_data() -> Result<(), errors::Error> {
                 avg10: 9.,
                 avg60: 10.,
                 avg300: 11.,
-                total: 12.,
+                total: 12,
             },
             full: processes::PressureAverages {
                 avg10: 13.,
                 avg60: 14.,
                 avg300: 15.,
-                total: 16.,
+                total: 16,
             },
         },
         cpu: processes::PressureData {
@@ -175,13 +175,13 @@ fn collect_process_data_full_pressure_data() -> Result<(), errors::Error> {
                 avg10: 17.,
                 avg60: 18.,
                 avg300: 19.,
-                total: 20.,
+                total: 20,
             },
             full: processes::PressureAverages {
                 avg10: 21.,
                 avg60: 22.,
                 avg300: 23.,
-                total: 24.,
+                total: 24,
             },
         },
     };


### PR DESCRIPTION
in some cases we should be using u64 instead of f32. this commit reassess all types in use in an effort to be more correct.