### PR TITLE
feat: prepare codebase to receive new signal senders

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -109,6 +109,17 @@ pub enum CheckerResult {
     None,
 }
 
+impl fmt::Display for CheckerResult {
+    fn fmt(&self, fp: &mut fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let as_string = match self {
+            CheckerResult::None => "none",
+            CheckerResult::Warning => "warning",
+            CheckerResult::Critical => "critical",
+        };
+        write!(fp, "{}", as_string)
+    }
+}
+
 // ThresholdsChecker is an entity capable of evaluting a CollectedData struct against a warning and
 // critical expressions. Both expressions are kept compiled into this struct for faster matching.
 pub struct ThresholdsChecker {

--- a/src/daemons.rs
+++ b/src/daemons.rs
@@ -1,7 +1,8 @@
-use super::arguments;
+use super::arguments::CheckerResult;
 use super::arguments::CheckerResult::Critical;
 use super::arguments::CheckerResult::None;
 use super::arguments::CheckerResult::Warning;
+use super::arguments::ThresholdsChecker;
 use super::events;
 use super::metrics;
 use super::processes;
@@ -9,7 +10,6 @@ use super::signals;
 use log::info;
 use log::warn;
 use moka::sync::Cache;
-use nix::sys::signal;
 use std::process;
 use std::sync::mpsc;
 use std::thread;
@@ -19,7 +19,7 @@ use std::time;
 #[derive(Debug, Clone)]
 struct SignalRecord {
     when: time::Instant,
-    kind: signal::Signal,
+    severity: CheckerResult,
 }
 
 // Monitor implements a daemon that monitors processes memory utilization on a system. The monitor
@@ -29,28 +29,26 @@ struct SignalRecord {
 // something to be used unbounded. cooldown_interval_secs governs how often we can send the same
 // signal towards the same pid while last_signals keeps track of previously sent signals. We limit
 // the historic data to 1_000 different pids, we do not expect this to ever go beyond this.
-pub struct Monitor<T: processes::ProcessProvider, S: events::Sender, U: signals::Sender> {
-    signal_sender: U,
+pub struct Monitor<'a, T: processes::ProcessProvider, S: events::Sender> {
+    signal_sender: &'a dyn signals::Sender,
     sink: S,
-    thresholds: arguments::ThresholdsChecker,
+    thresholds: ThresholdsChecker,
     processes_discover: T,
     loop_interval: time::Duration,
     last_signals: Cache<i32, SignalRecord>,
-    warning_signal: signal::Signal,
-    critical_signal: signal::Signal,
     cooldown_interval: time::Duration,
     metrics_server: metrics::Server,
 }
 
-impl<T: processes::ProcessProvider, S: events::Sender, U: signals::Sender> Monitor<T, S, U> {
+impl<'a, T: processes::ProcessProvider, S: events::Sender> Monitor<'a, T, S> {
     // new returns a new cgroups monitor. Sink is used to send all events, warning and critical are
     // used to assess the memory usage while last_signals is used to keep track when was the last
     // time we signaled a process.
     pub fn new(
         sink: S,
-        thresholds: arguments::ThresholdsChecker,
+        thresholds: ThresholdsChecker,
         processes_discover: T,
-        signal_sender: U,
+        signal_sender: &'a dyn signals::Sender,
     ) -> Self {
         Monitor {
             signal_sender,
@@ -59,8 +57,6 @@ impl<T: processes::ProcessProvider, S: events::Sender, U: signals::Sender> Monit
             processes_discover,
             loop_interval: time::Duration::from_millis(100),
             last_signals: Cache::new(1_000),
-            warning_signal: signal::Signal::SIGUSR1,
-            critical_signal: signal::Signal::SIGUSR2,
             cooldown_interval: time::Duration::from_secs(30),
             metrics_server: metrics::Server::default(),
         }
@@ -76,19 +72,6 @@ impl<T: processes::ProcessProvider, S: events::Sender, U: signals::Sender> Monit
     // with_cooldown_interval sets the minimum time between sends of the same signal.
     pub fn with_cooldown_interval(mut self, cooldown_interval: time::Duration) -> Self {
         self.cooldown_interval = cooldown_interval;
-        self
-    }
-
-    // with_warning_signal sets the signal to be sent upon warning threshold cross.
-    pub fn with_warning_signal(mut self, warning_signal: signal::Signal) -> Self {
-        self.warning_signal = warning_signal;
-        self
-    }
-
-    // with_critical_signal sets the signal to be sent when a process crosses the critical
-    // watermark.
-    pub fn with_critical_signal(mut self, critical_signal: signal::Signal) -> Self {
-        self.critical_signal = critical_signal;
         self
     }
 
@@ -155,11 +138,8 @@ impl<T: processes::ProcessProvider, S: events::Sender, U: signals::Sender> Monit
                 }
 
                 match self.thresholds.against(&mut cd) {
-                    Ok(result) => match result {
-                        Critical => {
-                            self.send_signal(&process, self.critical_signal, &cd, "critical")
-                        }
-                        Warning => self.send_signal(&process, self.warning_signal, &cd, "warning"),
+                    Ok(severity) => match severity {
+                        Warning | Critical => self.send_signal(&process, severity, &cd),
                         None => self.sink.send(
                             events::Event::low_prio()
                                 .with_process_collected_data(&process, &cd)
@@ -196,12 +176,11 @@ impl<T: processes::ProcessProvider, S: events::Sender, U: signals::Sender> Monit
     fn send_signal(
         &self,
         process: &processes::Process,
-        sig: signal::Signal,
+        severity: CheckerResult,
         cd: &processes::CollectedData,
-        desc: &str,
     ) {
         if let Some(last_signal) = self.last_signals.get(&process.pid)
-            && last_signal.kind == sig
+            && last_signal.severity == severity
         {
             let elapsed = time::Instant::now() - last_signal.when;
             if elapsed < self.cooldown_interval {
@@ -209,11 +188,11 @@ impl<T: processes::ProcessProvider, S: events::Sender, U: signals::Sender> Monit
             }
         }
 
-        if let Err(err) = self.signal_sender.send(sig, process.pid) {
+        if let Err(err) = self.signal_sender.send(&severity, process, cd) {
             self.sink.send(
                 events::Event::high_prio()
                     .with_process_collected_data(process, cd)
-                    .with_message(format!("fail sending {desc} signal: {err}")),
+                    .with_message(format!("error sending {:?} signal: {err}", severity)),
             );
             return;
         }
@@ -222,14 +201,14 @@ impl<T: processes::ProcessProvider, S: events::Sender, U: signals::Sender> Monit
             process.pid,
             SignalRecord {
                 when: time::Instant::now(),
-                kind: sig,
+                severity: severity.clone(),
             },
         );
 
         self.sink.send(
             events::Event::high_prio()
                 .with_process_collected_data(process, cd)
-                .with_message(format!("{desc} signal sent successfully")),
+                .with_message(format!("{severity} signal sent successfully")),
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,13 +46,12 @@ fn main() {
     let tx = events::Transmitter::new(evt_transmitter);
     let syscgroups = system::SystemCGroups::default();
     let processes_explorer = processes::ProcFsReader::new(syscgroups);
-    let signal_sender = signals::SignalSender::default();
-    let monitor = daemons::Monitor::new(tx, thresholds_checker, processes_explorer, signal_sender)
+    let signal_sender = signals::UnixSignalSender::new(flags.warning_signal, flags.critical_signal);
+
+    daemons::Monitor::new(tx, thresholds_checker, processes_explorer, &signal_sender)
         .with_cooldown_interval(flags.cooldown_interval)
         .with_loop_interval(flags.loop_interval)
-        .with_warning_signal(flags.warning_signal)
-        .with_critical_signal(flags.critical_signal);
-    monitor.run(stop_receiver);
+        .run(stop_receiver);
 }
 
 // signal_handler installs a signal handler for interrupt and terminate. Once one of these signals

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,23 +1,61 @@
+use super::arguments;
 use super::errors;
+use super::processes;
 use mockall::automock;
 use nix::sys::signal;
 use nix::unistd;
 
-// Sender is the trait implemented by the signal sender. We have this mostly for testing purposes
-// as we only have one signal sender anyways.
+// Sender is the trait implemented by the signal dispatcher. On its more simple form it is just a
+// call to signal::kill(pid, sig) but it can get some extra implementations (e.g. do a http request
+// to a different service). Implementations should be aware that send() is a blocker call from
+// the oomhero loop perpective.
 #[automock]
 pub trait Sender {
-    fn send(&self, sig: signal::Signal, pid: i32) -> Result<(), errors::Error>;
+    fn send(
+        &self,
+        severity: &arguments::CheckerResult,
+        process: &processes::Process,
+        cd: &processes::CollectedData,
+    ) -> Result<(), errors::Error>;
 }
 
-// SignalSender is the entity that sends a unix signal to a given process.
-#[derive(Debug, Default)]
-pub struct SignalSender {}
+// UnixSignalSender is the entity that sends a unix signal to a given process.
+#[derive(Debug)]
+pub struct UnixSignalSender {
+    pub warning: signal::Signal,
+    pub critical: signal::Signal,
+}
 
-impl Sender for SignalSender {
-    // send sends a signal to a process pointed by pid.
-    fn send(&self, sig: signal::Signal, pid: i32) -> Result<(), errors::Error> {
-        let pid = unistd::Pid::from_raw(pid);
+impl UnixSignalSender {
+    pub fn new(warning: signal::Signal, critical: signal::Signal) -> Self {
+        Self { warning, critical }
+    }
+}
+
+impl Default for UnixSignalSender {
+    fn default() -> Self {
+        Self {
+            warning: signal::SIGUSR1,
+            critical: signal::SIGUSR2,
+        }
+    }
+}
+
+impl Sender for UnixSignalSender {
+    // send sends a signal to a process pointed by pid. the signal sent depends on the severity
+    // that can be either critical or warning (if none then the signal is just ignored).
+    fn send(
+        &self,
+        severity: &arguments::CheckerResult,
+        process: &processes::Process,
+        _: &processes::CollectedData,
+    ) -> Result<(), errors::Error> {
+        let sig = match severity {
+            arguments::CheckerResult::None => return Ok(()),
+            arguments::CheckerResult::Warning => self.warning,
+            arguments::CheckerResult::Critical => self.critical,
+        };
+        let pid = unistd::Pid::from_raw(process.pid);
         Ok(signal::kill(pid, sig)?)
     }
 }

--- a/tests/daemons_run.rs
+++ b/tests/daemons_run.rs
@@ -1,6 +1,8 @@
 use mockall::predicate;
 use nix::sys::signal;
 use oomhero::arguments;
+use oomhero::arguments::CheckerResult::Critical;
+use oomhero::arguments::CheckerResult::Warning;
 use oomhero::daemons;
 use oomhero::errors;
 use oomhero::events;
@@ -52,9 +54,9 @@ fn daemons_run_processes_cooldown_enforcement() -> Result<(), errors::Error> {
     signals_sender
         .expect_send()
         .times(1)
-        .returning(move |sig, pid| {
-            assert_eq!(sig, signal::SIGKILL);
-            assert_eq!(pid, 2);
+        .returning(move |sev, process, _cd| {
+            assert_eq!(sev, &Critical);
+            assert_eq!(process.pid, 2);
             Ok(())
         });
 
@@ -68,10 +70,9 @@ fn daemons_run_processes_cooldown_enforcement() -> Result<(), errors::Error> {
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(10))
-    .with_critical_signal(signal::SIGKILL)
     .with_cooldown_interval(time::Duration::from_secs(60));
     monitor.run(rx);
     Ok(())
@@ -144,9 +145,9 @@ fn daemons_run_processes_exclusion() -> Result<(), errors::Error> {
         .times(0);
 
     let mut signals_sender = signals::MockSender::new();
-    signals_sender.expect_send().returning(|sig, pid| {
-        assert_eq!(sig, signal::SIGUSR1);
-        assert_eq!(pid, 2);
+    signals_sender.expect_send().returning(|sev, process, _cd| {
+        assert_eq!(sev, &Warning);
+        assert_eq!(process.pid, 2);
         Ok(())
     });
 
@@ -159,7 +160,7 @@ fn daemons_run_processes_exclusion() -> Result<(), errors::Error> {
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
     .with_cooldown_interval(time::Duration::from_mins(1));
@@ -220,9 +221,9 @@ fn daemons_run_processes_with_cpu_pressure_critical() -> Result<(), errors::Erro
         });
 
     let mut signals_sender = signals::MockSender::new();
-    signals_sender.expect_send().returning(|sig, pid| {
-        assert_eq!(sig, signal::SIGUSR2);
-        assert_eq!(pid, 2);
+    signals_sender.expect_send().returning(|sev, process, _cd| {
+        assert_eq!(sev, &Critical);
+        assert_eq!(process.pid, 2);
         Ok(())
     });
 
@@ -235,7 +236,7 @@ fn daemons_run_processes_with_cpu_pressure_critical() -> Result<(), errors::Erro
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
     .with_cooldown_interval(time::Duration::from_mins(1));
@@ -299,7 +300,7 @@ fn daemons_run_processes_with_critical_but_only_pressure_thresholds() -> Result<
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
     .with_cooldown_interval(time::Duration::from_mins(1));
@@ -354,11 +355,13 @@ fn daemons_run_processes_with_critical() -> Result<(), errors::Error> {
         });
 
     let mut signals_sender = signals::MockSender::new();
-    signals_sender.expect_send().returning(move |sig, pid| {
-        assert_eq!(sig, signal::SIGKILL);
-        assert_eq!(pid, 2);
-        Ok(())
-    });
+    signals_sender
+        .expect_send()
+        .returning(move |sev, process, _cd| {
+            assert_eq!(sev, &Critical);
+            assert_eq!(process.pid, 2);
+            Ok(())
+        });
 
     thread::spawn(move || {
         std::thread::sleep(time::Duration::from_millis(200));
@@ -369,10 +372,9 @@ fn daemons_run_processes_with_critical() -> Result<(), errors::Error> {
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
-    .with_critical_signal(signal::SIGKILL)
     .with_cooldown_interval(time::Duration::from_mins(1));
     monitor.run(rx);
     Ok(())
@@ -431,11 +433,13 @@ fn daemons_run_processes_with_io_pressure_critical() -> Result<(), errors::Error
         });
 
     let mut signals_sender = signals::MockSender::new();
-    signals_sender.expect_send().returning(move |sig, pid| {
-        assert_eq!(sig, signal::SIGABRT);
-        assert_eq!(pid, 2);
-        Ok(())
-    });
+    signals_sender
+        .expect_send()
+        .returning(move |sev, process, _cd| {
+            assert_eq!(sev, &Critical);
+            assert_eq!(process.pid, 2);
+            Ok(())
+        });
 
     thread::spawn(move || {
         std::thread::sleep(time::Duration::from_millis(200));
@@ -446,10 +450,9 @@ fn daemons_run_processes_with_io_pressure_critical() -> Result<(), errors::Error
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
-    .with_critical_signal(signal::SIGABRT)
     .with_cooldown_interval(time::Duration::from_mins(1));
     monitor.run(rx);
     Ok(())
@@ -511,11 +514,13 @@ fn daemons_run_processes_with_memory_pressure_critical() -> Result<(), errors::E
         });
 
     let mut signals_sender = signals::MockSender::new();
-    signals_sender.expect_send().returning(move |sig, pid| {
-        assert_eq!(sig, signal::SIGKILL);
-        assert_eq!(pid, 2);
-        Ok(())
-    });
+    signals_sender
+        .expect_send()
+        .returning(move |sev, process, _cd| {
+            assert_eq!(sev, &Critical);
+            assert_eq!(process.pid, 2);
+            Ok(())
+        });
 
     thread::spawn(move || {
         std::thread::sleep(time::Duration::from_millis(200));
@@ -526,10 +531,9 @@ fn daemons_run_processes_with_memory_pressure_critical() -> Result<(), errors::E
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
-    .with_critical_signal(signal::SIGKILL)
     .with_cooldown_interval(time::Duration::from_mins(1));
     monitor.run(rx);
     Ok(())
@@ -591,11 +595,13 @@ fn daemons_run_processes_with_mixed_thresholds_critical_precedence() -> Result<(
         });
 
     let mut signals_sender = signals::MockSender::new();
-    signals_sender.expect_send().returning(move |sig, pid| {
-        assert_eq!(sig, signal::SIGKILL);
-        assert_eq!(pid, 2);
-        Ok(())
-    });
+    signals_sender
+        .expect_send()
+        .returning(move |sev, process, _cd| {
+            assert_eq!(sev, &Critical);
+            assert_eq!(process.pid, 2);
+            Ok(())
+        });
 
     thread::spawn(move || {
         std::thread::sleep(time::Duration::from_millis(200));
@@ -606,11 +612,9 @@ fn daemons_run_processes_with_mixed_thresholds_critical_precedence() -> Result<(
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
-    .with_critical_signal(signal::SIGKILL)
-    .with_warning_signal(signal::SIGUSR1)
     .with_cooldown_interval(time::Duration::from_mins(1));
     monitor.run(rx);
     Ok(())
@@ -663,11 +667,13 @@ fn daemons_run_processes_with_warning() -> Result<(), errors::Error> {
         });
 
     let mut signals_sender = signals::MockSender::new();
-    signals_sender.expect_send().returning(move |sig, pid| {
-        assert_eq!(sig, signal::SIGUSR1);
-        assert_eq!(pid, 2);
-        Ok(())
-    });
+    signals_sender
+        .expect_send()
+        .returning(move |sev, process, _cd| {
+            assert_eq!(sev, &Warning);
+            assert_eq!(process.pid, 2);
+            Ok(())
+        });
 
     thread::spawn(move || {
         std::thread::sleep(time::Duration::from_millis(200));
@@ -678,7 +684,7 @@ fn daemons_run_processes_with_warning() -> Result<(), errors::Error> {
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
     .with_cooldown_interval(time::Duration::from_mins(1));
@@ -760,7 +766,7 @@ fn daemons_run_processes_within_limits() -> Result<(), errors::Error> {
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
     .with_cooldown_interval(time::Duration::from_mins(1));
@@ -814,7 +820,7 @@ fn daemons_run_fail_collecting_process_data() -> Result<(), errors::Error> {
         events_sink,
         arguments.thresholds_checker().unwrap(),
         processes_explorer,
-        signals_sender,
+        &signals_sender,
     )
     .with_loop_interval(time::Duration::from_millis(50))
     .with_cooldown_interval(time::Duration::from_mins(1));


### PR DESCRIPTION
for now we only have the unix signal sender (sends a posix signal) but now we have opened the codebase for new kinds of singnals.

i can see someone wanting to do a http callback instead of sending the signals. maybe slack integration, i don't know. the heavy lift to support these kinds of integrations is now done.