### PR TITLE
feat: add timeout for http notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oomhero"
-version = "3.0.6"
+version = "3.0.7"
 dependencies = [
  "clap",
  "duration-str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oomhero"
-version = "3.0.6"
+version = "3.0.7"
 edition = "2024"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -265,8 +265,12 @@ headers:
 | `--http-file-path` | Path to HTTP notification config (conflicts with signal options) | (none) |
 | `--version` | Display version information | false |
 
-**Note**: Both `--warning` and `--critical` expressions must be provided for
-OOMHero to run.
+> [!IMPORTANT]
+> Both `--warning` and `--critical` expressions must be provided for OOMHero to
+> run. HTTP notifications are sent synchronously. To prevent slow webhooks from
+> stalling the process monitoring loop, a 3-second timeout is applied to each
+> request. If a notification fails or times out, OOMHero will log the error and
+> continue monitoring other processes.
 
 ## Important Considerations
 

--- a/src/http_signals_sender.rs
+++ b/src/http_signals_sender.rs
@@ -61,7 +61,12 @@ impl signals::Sender for HttpSignalSender {
             collected_data: cd.clone(),
         };
 
-        let mut builder = ureq::post(&self.config.url);
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .timeout_global(Some(std::time::Duration::from_secs(3)))
+            .build()
+            .into();
+
+        let mut builder = agent.post(&self.config.url);
         for header in &self.config.headers {
             builder = builder.header(&header.name, &header.value);
         }


### PR DESCRIPTION
these requests are blocking operations so we can't leave them unbounded.